### PR TITLE
Decoder and list combinator

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -22,6 +22,9 @@ hashes :: forall e. (String -> String -> Eff e Unit) -> Eff e Unit
 matches :: forall e a. Match a -> (Maybe a -> a -> Eff e Unit) -> Eff e Unit
 ```
 
+Stream of hash changed, callback called when new hash can be matched
+First argument of callback is `Just a` when old hash can be matched
+and `Nothing` when it can't.
 
 #### `matches'`
 

--- a/MODULES.md
+++ b/MODULES.md
@@ -23,10 +23,24 @@ matches :: forall e a. Match a -> (Maybe a -> a -> Eff e Unit) -> Eff e Unit
 ```
 
 
+#### `matches'`
+
+``` purescript
+matches' :: forall e a. (String -> String) -> Match a -> (Maybe a -> a -> Eff e Unit) -> Eff e Unit
+```
+
+
 #### `matchHash`
 
 ``` purescript
 matchHash :: forall a. Match a -> String -> Either String a
+```
+
+
+#### `matchHash'`
+
+``` purescript
+matchHash' :: forall a. (String -> String) -> Match a -> String -> Either String a
 ```
 
 
@@ -114,6 +128,15 @@ instance matchApplicative :: Applicative Match
 ```
 
 
+#### `list`
+
+``` purescript
+list :: forall a. Match a -> Match (List a)
+```
+
+Matches list of matchers. Useful when argument can easy fail (not `str`)
+returns `Match Nil` if no matches
+
 #### `runMatch`
 
 ``` purescript
@@ -149,9 +172,11 @@ routes = (pure Routing) <*> (eitherMatch (sortOfString <$> var))
 #### `parse`
 
 ``` purescript
-parse :: String -> Route
+parse :: (String -> String) -> String -> Route
 ```
 
+Parse hash string to `Route` with `decoder` function
+applied to every hash part (usually `decodeURIComponent`)
 
 
 ## Module Routing.Types

--- a/src/Routing.purs
+++ b/src/Routing.purs
@@ -38,6 +38,9 @@ hashes cb =
   where dropHash h = R.replace (R.regex "^[^#]*#" R.noFlags) "" h
 
 
+-- | Stream of hash changed, callback called when new hash can be matched
+-- | First argument of callback is `Just a` when old hash can be matched
+-- | and `Nothing` when it can't.
 matches :: forall e a. Match a -> (Maybe a -> a -> Eff e Unit) -> Eff e Unit
 matches = matches' decodeURIComponent
 

--- a/src/Routing/Match.purs
+++ b/src/Routing/Match.purs
@@ -21,6 +21,8 @@ import Routing.Types
 import Routing.Match.Class
 import Routing.Match.Error
 
+import Debug.Foreign
+
 newtype Match a = Match (Route -> V (Free MatchError) (Tuple Route a)) 
 
 instance matchMatchClass :: MatchClass Match where
@@ -95,6 +97,22 @@ instance matchApply :: Apply Match where
 
 instance matchApplicative :: Applicative Match where
   pure a = Match \r -> pure $ Tuple r a
+
+
+-- | Matches list of matchers. Useful when argument can easy fail (not `str`)
+-- | returns `Match Nil` if no matches
+list :: forall a. Match a -> Match (List a)
+list (Match r2a) =
+  Match $ go Nil
+  where go :: List a -> Route -> V (Free MatchError) (Tuple Route (List a))
+        go accum r =
+          runV
+          (const $ pure (Tuple r (reverse accum)))
+          (\(Tuple rs a) -> go (Cons a accum) rs)
+          (r2a r)
+          
+
+
 
 -- It groups `Free MatchError` -> [[MatchError]] -map with showMatchError ->
 -- [[String]] -fold with semicolon-> [String] -fold with newline-> String 

--- a/src/Routing/Match.purs
+++ b/src/Routing/Match.purs
@@ -21,8 +21,6 @@ import Routing.Types
 import Routing.Match.Class
 import Routing.Match.Error
 
-import Debug.Foreign
-
 newtype Match a = Match (Route -> V (Free MatchError) (Tuple Route a)) 
 
 instance matchMatchClass :: MatchClass Match where

--- a/src/Routing/Parser.purs
+++ b/src/Routing/Parser.purs
@@ -26,11 +26,12 @@ tryQuery source@(Path string) = fromMaybe source $ do
           Tuple <$> (A.head keyVal) <*> (keyVal A.!! 1)
 tryQuery q = q
 
-foreign import decodeURIComponent :: String -> String
 
-parse :: String -> Route
-parse hash = tryQuery <$>
+-- | Parse hash string to `Route` with `decoder` function
+-- | applied to every hash part (usually `decodeURIComponent`)
+parse :: (String -> String) -> String -> Route
+parse decoder hash = tryQuery <$>
              Path <$>
-             decodeURIComponent <$>
+             decoder <$> 
              fromArray (S.split "/" hash)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,19 +5,22 @@ import Debug.Trace
 import Control.Alt
 import Control.Apply
 import Debug.Foreign
-
+import Data.List
 
 import Routing
 import Routing.Match
 import Routing.Match.Class
 
-data FooBar = Foo Number | Bar Boolean String
+data FooBar = Foo Number | Bar Boolean String | Baz (List Number) 
 
 routing :: Match FooBar
 routing =
   Foo <$> (lit "foo" *> num)
   <|>
   Bar <$> (lit "bar" *> bool) <*> (param "baz")
+  <|>
+  Baz <$> (list num)
+
 
 main = do
   fprint $ matchHash routing "food/asdf"


### PR DESCRIPTION
* Added functions to provide a way to explicit set decoder for uri (not only `decodeURIComponent`)
* Added `list` combinator that matches provided matcher as argument many times and yields `Match (List a)`