### PR TITLE
Add `params` to `MatchClass`

### DIFF
--- a/docs/Routing/Match.md
+++ b/docs/Routing/Match.md
@@ -9,13 +9,13 @@ newtype Match a
 
 ##### Instances
 ``` purescript
-instance matchMatchClass :: MatchClass Match
-instance matchFunctor :: Functor Match
-instance matchAlt :: Alt Match
-instance matchPlus :: Plus Match
-instance matchAlternative :: Alternative Match
-instance matchApply :: Apply Match
-instance matchApplicative :: Applicative Match
+MatchClass Match
+Functor Match
+Alt Match
+Plus Match
+Alternative Match
+Apply Match
+Applicative Match
 ```
 
 #### `unMatch`

--- a/docs/Routing/Match/Class.md
+++ b/docs/Routing/Match/Class.md
@@ -7,6 +7,7 @@ class (Alternative f) <= MatchClass f where
   lit :: String -> f Unit
   str :: f String
   param :: String -> f String
+  params :: f (Map String String)
   num :: f Number
   bool :: f Boolean
   fail :: forall a. String -> f a

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/slamdata/purescript-routing",
   "dependencies": {
     "gulp": "^3.9.0",
-    "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.4"
+    "gulp-purescript": "^0.8.0",
+    "purescript": "^0.7.6"
   }
 }

--- a/src/Routing/Match/Class.purs
+++ b/src/Routing/Match/Class.purs
@@ -2,11 +2,31 @@ module Routing.Match.Class where
 
 import Prelude
 import Control.Alternative (Alternative)
+import Data.Map as M
 
 class (Alternative f) <= MatchClass f where
+  -- | `lit x` will match exactly the path component `x`.
+  -- | For example, `lit "x"` matches `/x`.
   lit :: String -> f Unit
+
+  -- | `str` matches any path string component.
+  -- | For example, `str` matches `/foo` as `"foo"`.
   str :: f String
+
+  -- | `param p` matches a parameter assignment `q=v` within a query block.
+  -- | For example, `param "q"` matches `/?q=a&r=b` as `"a"`.
   param :: String -> f String
+
+  -- | `params` matches an entire query block. For exmaple, `params`
+  -- | matches `/?q=a&r=b` as the map `{q : "a", r : "b"}`. Note that
+  -- | `lit "foo" *> params` does *not* match `/foo`, since a query component
+  -- | is *required*.
+  params :: f (M.Map String String)
+
+  -- | `num` matches any numerical path component.
   num :: f Number
+
+  -- | `bool` matches any boolean path component.
   bool :: f Boolean
+
   fail :: forall a. String -> f a

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -6,30 +6,30 @@ import Control.Monad.Eff.Console
 import Control.Alt
 import Control.Apply
 import Data.List
+import Data.Map as M
 
 
 import Routing
 import Routing.Match
 import Routing.Match.Class
 
-data FooBar = Foo Number | Bar Boolean String | Baz (List Number)
+data FooBar = Foo Number (M.Map String String) | Bar Boolean String | Baz (List Number)
 
 instance showFooBar :: Show FooBar where
-  show (Foo num) = "(Foo " <> show num <> " )"
-  show (Bar bool str) = "(Bar " <> show bool <> " " <> show str <> " )"
-  show (Baz lst) = "(Baz " <> show lst <> " )"
+  show (Foo num q) = "(Foo " <> show num <> " " <> show q <> ")"
+  show (Bar bool str) = "(Bar " <> show bool <> " " <> show str <> ")"
+  show (Baz lst) = "(Baz " <> show lst <> ")"
 
 routing :: Match FooBar
 routing =
-  Foo <$> (lit "foo" *> num)
-  <|>
-  Bar <$> (lit "bar" *> bool) <*> (param "baz")
-  <|>
-  Baz <$> (list num)
+  Foo <$> (lit "foo" *> num) <*> params
+    <|> Bar <$> (lit "bar" *> bool) <*> (param "baz")
+    <|> Baz <$> (list num)
 
 
+main :: Eff (console :: CONSOLE) Unit
 main = do
-  print $ matchHash routing "foo/12"
+  print $ matchHash routing "foo/12/?welp='hi'&b=false"
   matches routing $ \old new -> void do
     print old
     print new


### PR DESCRIPTION
- Added `params` to `MatchClass`, which will capture a whole block of parameters as a map
- Updated the build deps 
- Fixed a couple warnings
- Regenerated docs