### PR TITLE
Fix for URI-encoded path segments without query fragment

### DIFF
--- a/src/Routing/Parser.purs
+++ b/src/Routing/Parser.purs
@@ -38,7 +38,7 @@ parse decoder hash =
   where
     pathParts str =
       let
-        parts = L.fromFoldable $ map Path (S.split (S.Pattern "/") str)
+        parts = L.fromFoldable $ map (Path <<< decoder) (S.split (S.Pattern "/") str)
       in
         case L.unsnoc parts of
           Just { init, last: Path "" } -> init

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -12,7 +12,7 @@ import Data.Map as M
 import Data.Tuple (Tuple(..))
 import Routing (match)
 import Routing.Match (Match, list)
-import Routing.Match.Class (bool, end, int, lit, num, param, params)
+import Routing.Match.Class (bool, end, int, lit, num, str, param, params)
 import Test.Assert (ASSERT, assert')
 
 data FooBar
@@ -20,6 +20,7 @@ data FooBar
   | Bar Boolean String
   | Baz (List Number)
   | Quux Int
+  | Corge String
   | End Int
 
 derive instance eqFooBar :: Eq FooBar
@@ -29,6 +30,7 @@ instance showFooBar :: Show FooBar where
   show (Bar bool str) = "(Bar " <> show bool <> " " <> show str <> ")"
   show (Baz lst) = "(Baz " <> show lst <> ")"
   show (Quux i) = "(Quux " <> show i <> ")"
+  show (Corge str) = "(Corge " <> show str <> ")"
   show (End i) = "(End " <> show i <> ")"
 
 routing :: Match FooBar
@@ -36,6 +38,7 @@ routing =
   Foo <$> (lit "foo" *> num) <*> params
     <|> Bar <$> (lit "bar" *> bool) <*> (param "baz")
     <|> Quux <$> (lit "" *> lit "quux" *> int)
+    <|> Corge <$> (lit "corge" *> str)
     -- Order matters here.  `list` is greedy, and `end` wont match after it
     <|> End <$> (lit "" *> int <* end)
     <|> Baz <$> (list num)
@@ -45,6 +48,10 @@ main :: Eff (assert :: ASSERT, console :: CONSOLE) Unit
 main = do
   assertEq (match routing "foo/12/?welp='hi'&b=false") (Right (Foo 12.0 (M.fromFoldable [Tuple "welp" "'hi'", Tuple "b" "false"])))
   assertEq (match routing "foo/12?welp='hi'&b=false") (Right (Foo 12.0 (M.fromFoldable [Tuple "welp" "'hi'", Tuple "b" "false"])))
+  assertEq (match routing "bar/true?baz=test") (Right (Bar true "test"))
+  assertEq (match routing "bar/false?baz=%D0%B2%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9%20%D1%84%D0%B0%D0%B9%D0%BB") (Right (Bar false "временный файл"))
+  assertEq (match routing "corge/test") (Right (Corge "test"))
+  assertEq (match routing "corge/%D0%B2%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9%20%D1%84%D0%B0%D0%B9%D0%BB") (Right (Corge "временный файл"))
   assertEq (match routing "/quux/42") (Right (Quux 42))
   assertEq (match routing "123/") (Right (Baz (L.fromFoldable [123.0])))
   assertEq (match routing "/1") (Right (End 1))


### PR DESCRIPTION
I already fixed this in the backport branch, this is just applying to master too.