### PR TITLE
Bump purescript-web-html to 2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-web-html": "^1.0.0",
+    "purescript-web-html": "^2.0.0",
     "purescript-effect": "^2.0.0",
     "purescript-either": "^4.0.0",
     "purescript-globals": "^4.0.0",


### PR DESCRIPTION
Get this error when trying to use `purescript-routing` together with `purescript-halogen@5.0.0-rc.3`

```
Unable to find a suitable version for purescript-web-html, please choose one by typing one of the numbers below:
    1) purescript-web-html#^1.0.0 which resolved to 1.2.0 and is required by purescript-routing#8.0.0
    2) purescript-web-html#^2.0.0 which resolved to 2.0.0 and is required by purescript-halogen-vdom#6.0.0, purescript-web-clipboard#2.0.0, purescript-web-uievents#2.0.0
```